### PR TITLE
[enhancement] MPU layer is abstracted

### DIFF
--- a/libkernel.gpr
+++ b/libkernel.gpr
@@ -23,8 +23,9 @@ library project Libkernel is
       "-gnata");        -- Enable pragma Assert | Debug
 
    verif :=
-     ("-gnato",         -- Turn on all checks
-      "-gnatVa");       -- Turn on all validity checks
+     ("-gnato");        -- Turn on all checks
+--     ("-gnato",         -- Turn on all checks
+--      "-gnatVa");       -- Turn on all validity checks
 
    no_verif :=
      ("-gnatp",         -- Turn off all checks

--- a/src/ewok-devices.ads
+++ b/src/ewok-devices.ads
@@ -24,7 +24,6 @@ with ewok.tasks_shared;    use ewok.tasks_shared;
 with ewok.devices_shared;  use ewok.devices_shared;
 with ewok.exported.devices;
 with ewok.exported.interrupts;
-with m4.mpu;
 with soc.interrupts;
 with soc.devmap;
 
@@ -50,31 +49,31 @@ is
       status      : t_device_state           := DEV_STATE_UNUSED;
    end record;
 
-   registered_device : array (t_device_id range ID_DEV1 .. ID_DEV18) of t_device;
+   registered_device : array (t_registered_device_id) of t_device;
 
 
    procedure get_registered_device_entry
      (dev_id   : out t_device_id;
       success  : out boolean);
 
-   procedure release_registered_device_entry (dev_id : t_device_id);
+   procedure release_registered_device_entry (dev_id : t_registered_device_id);
 
-   function get_task_from_id(dev_id : t_device_id)
+   function get_task_from_id(dev_id : t_registered_device_id)
       return t_task_id;
 
-   function get_user_device (dev_id : t_device_id)
+   function get_user_device (dev_id : t_registered_device_id)
       return t_checked_user_device_access;
 
-   function get_user_device_size (dev_id : t_device_id)
+   function get_device_size (dev_id : t_registered_device_id)
       return unsigned_32;
 
-   function get_user_device_addr (dev_id : t_device_id)
+   function get_device_addr (dev_id : t_registered_device_id)
       return system_address;
 
-   function is_user_device_region_ro (dev_id : t_device_id)
+   function is_device_region_ro (dev_id : t_registered_device_id)
       return boolean;
 
-   function get_user_device_subregions_mask (dev_id : t_device_id)
+   function get_device_subregions_mask (dev_id : t_registered_device_id)
       return unsigned_8;
 
    function get_interrupt_config_from_interrupt
@@ -89,11 +88,11 @@ is
 
    procedure release_device
      (task_id  : in  t_task_id;
-      dev_id   : in  t_device_id;
+      dev_id   : in  t_registered_device_id;
       success  : out boolean);
 
    procedure enable_device
-     (dev_id   : in  t_device_id;
+     (dev_id   : in  t_registered_device_id;
       success  : out boolean);
 
    function sanitize_user_defined_device
@@ -101,9 +100,11 @@ is
       task_id  : in  t_task_id)
       return boolean;
 
-   procedure mpu_mapping_device
-     (dev_id   : in  t_device_id;
-      region   : in  m4.mpu.t_region_number;
+   procedure map_device
+     (dev_id   : in  t_registered_device_id;
       success  : out boolean);
+
+   procedure unmap_device
+     (dev_id   : in  t_registered_device_id);
 
 end ewok.devices;

--- a/src/ewok-devices_shared.ads
+++ b/src/ewok-devices_shared.ads
@@ -27,23 +27,10 @@ is
 
    type t_device_id is
      (ID_DEV_UNUSED,
-      ID_DEV1,
-      ID_DEV2,
-      ID_DEV3,
-      ID_DEV4,
-      ID_DEV5,
-      ID_DEV6,
-      ID_DEV7,
-      ID_DEV8,
-      ID_DEV9,
-      ID_DEV10,
-      ID_DEV11,
-      ID_DEV12,
-      ID_DEV13,
-      ID_DEV14,
-      ID_DEV15,
-      ID_DEV16,
-      ID_DEV17,
-      ID_DEV18);
+      ID_DEV1,  ID_DEV2,  ID_DEV3,  ID_DEV4,  ID_DEV5,  ID_DEV6,
+      ID_DEV7,  ID_DEV8,  ID_DEV9,  ID_DEV10, ID_DEV11, ID_DEV12,
+      ID_DEV13, ID_DEV14, ID_DEV15, ID_DEV16, ID_DEV17, ID_DEV18);
+
+   subtype t_registered_device_id is t_device_id range ID_DEV1 .. ID_DEV18;
 
 end ewok.devices_shared;

--- a/src/ewok-mpu.ads
+++ b/src/ewok-mpu.ads
@@ -42,20 +42,12 @@ is
    KERN_CODE_REGION        : constant m4.mpu.t_region_number := 0;
    KERN_DEVICES_REGION     : constant m4.mpu.t_region_number := 1;
    KERN_DATA_REGION        : constant m4.mpu.t_region_number := 2;
-   USER_DATA_REGION        : constant m4.mpu.t_region_number := 3; -- USER_RAM
-   USER_CODE_REGION        : constant m4.mpu.t_region_number := 4; -- USER_TXT
-   USER_ISR_STACK_REGION   : constant m4.mpu.t_region_number := 5;
-   USER_DEV1_REGION        : constant m4.mpu.t_region_number := 5;
-   USER_ISR_DEVICE_REGION  : constant m4.mpu.t_region_number := 6;
-   USER_DEV2_REGION        : constant m4.mpu.t_region_number := 6;
-   USER_SHARED_REGION      : constant m4.mpu.t_region_number := 7;
+   USER_CODE_REGION        : constant m4.mpu.t_region_number := 3; -- USER_TXT
+   USER_DATA_REGION        : constant m4.mpu.t_region_number := 4; -- USER_RAM
+   USER_DATA_SHARED_REGION : constant m4.mpu.t_region_number := 5;
+   USER_FREE_1_REGION      : constant m4.mpu.t_region_number := 6;
+   USER_FREE_2_REGION      : constant m4.mpu.t_region_number := 7;
 
-   -- How many devices can be mapped in memory
-   MAX_DEVICE_REGIONS   : constant := 2;
-   device_regions       :
-      constant array (unsigned_8 range 1 .. MAX_DEVICE_REGIONS) of
-         m4.mpu.t_region_number
-      := (USER_DEV1_REGION, USER_DEV2_REGION);
 
    ---------------
    -- Functions --
@@ -118,5 +110,34 @@ is
       region_size : out m4.mpu.t_region_size;
       success     : out boolean)
       with global => null;
+
+   -------------------------------
+   -- Pool of available regions --
+   -------------------------------
+
+   type t_region_entry is record
+      used     : boolean := false;  -- is region used?
+      addr     : system_address;    -- base address
+   end record;
+
+   regions_pool   : array
+     (m4.mpu.t_region_number range USER_FREE_1_REGION .. USER_FREE_2_REGION)
+      of t_region_entry
+         := (others => (false, 0));
+
+   function can_be_mapped return boolean;
+
+   procedure map
+     (addr           : in  system_address;
+      size           : in  unsigned_32;
+      region_type    : in  ewok.mpu.t_region_type;
+      subregion_mask : in  unsigned_8;
+      success        : out boolean);
+
+   procedure unmap
+     (addr           : in  system_address);
+
+   procedure unmap_all;
+
 
 end ewok.mpu;

--- a/src/ewok-posthook.adb
+++ b/src/ewok-posthook.adb
@@ -85,7 +85,7 @@ is
          return;
       end if;
 
-      dev_addr := ewok.devices.get_user_device_addr (dev_id);
+      dev_addr := ewok.devices.get_device_addr (dev_id);
 
       for i in config.all.posthook.action'range loop
          case config.all.posthook.action(i).instr is

--- a/src/ewok-sanitize.adb
+++ b/src/ewok-sanitize.adb
@@ -90,11 +90,11 @@ is
       user_task   : ewok.tasks.t_task renames ewok.tasks.tasks_list(task_id);
    begin
 
-      for i in user_task.device_id'range loop
-         dev_id   := user_task.device_id(i);
+      for i in user_task.devices'range loop
+         dev_id   := user_task.devices(i).device_id;
          if dev_id /= ID_DEV_UNUSED then
-            dev_addr := ewok.devices.get_user_device_addr (dev_id);
-            dev_size := ewok.devices.get_user_device_size (dev_id);
+            dev_addr := ewok.devices.get_device_addr (dev_id);
+            dev_size := ewok.devices.get_device_size (dev_id);
             if ptr >= dev_addr         and
                ptr + 4 >= dev_addr     and
                ptr + 4 < dev_addr + dev_size
@@ -135,11 +135,11 @@ is
       user_task : ewok.tasks.t_task renames ewok.tasks.tasks_list(task_id);
    begin
 
-      for i in user_task.device_id'range loop
-         dev_id   := user_task.device_id(i);
+      for i in user_task.devices'range loop
+         dev_id   := user_task.devices(i).device_id;
          if dev_id /= ID_DEV_UNUSED then
-            user_device_size := ewok.devices.get_user_device_size(dev_id);
-            user_device_addr := ewok.devices.get_user_device_addr(dev_id);
+            user_device_size := ewok.devices.get_device_size (dev_id);
+            user_device_addr := ewok.devices.get_device_addr (dev_id);
             if ptr >= user_device_addr                            and
                ptr + size <= user_device_addr + user_device_size
             then

--- a/src/ewok-tasks.ads
+++ b/src/ewok-tasks.ads
@@ -26,7 +26,6 @@ with ewok.devices_shared;  use ewok.devices_shared;
 with ewok.ipc;
 with ewok.exported.dma;
 with ewok.dma_shared;
-with ewok.mpu;
 with soc;
 with soc.layout;
 
@@ -118,9 +117,12 @@ is
    type t_dma_shm_info_list is array (unsigned_32 range <>) of
       ewok.exported.dma.t_dma_shm_info;
 
-   type t_device_id_list is array (unsigned_8 range <>) of
-      ewok.devices_shared.t_device_id
-         with default_component_value => ID_DEV_UNUSED;
+   type t_device is record
+      device_id   : ewok.devices_shared.t_device_id   := ID_DEV_UNUSED;
+      mounted     : boolean                           := false;
+   end record;
+
+   type t_device_list is array (unsigned_8 range <>) of t_device;
 
    type t_ipc_endpoint_id_list is array (ewok.tasks_shared.t_task_id) of
       ewok.ipc.t_extended_endpoint_id
@@ -149,9 +151,7 @@ is
       num_dma_id        : unsigned_32 range 0 .. MAX_DMAS_PER_TASK      := 0;
       dma_id            : t_registered_dma_index_list (1 .. MAX_DMAS_PER_TASK);
       num_devs          : unsigned_8 range 0 .. MAX_DEVS_PER_TASK       := 0;
-      device_id         : t_device_id_list (1 .. MAX_DEVS_PER_TASK);
-      num_devs_mounted  : unsigned_8 range 0 .. ewok.mpu.MAX_DEVICE_REGIONS := 0;
-      mounted_device    : t_device_id_list (1 .. ewok.mpu.MAX_DEVICE_REGIONS);
+      devices           : t_device_list (1 .. MAX_DEVS_PER_TASK);
       init_done         : boolean         := false;
       data_slot_start   : system_address  := 0;
       data_slot_end     : system_address  := 0;
@@ -287,27 +287,25 @@ is
                      descriptor = 0
                   else
                      descriptor > 0 and
-                     descriptor < tasks_list(id).device_id'last
-                  );
+                     descriptor < tasks_list(id).devices'last);
 
    procedure remove_device
-     (id       : in  ewok.tasks_shared.t_task_id;
-      dev_id   : in  ewok.devices_shared.t_device_id;
-      success  : out boolean);
+     (id             : in  ewok.tasks_shared.t_task_id;
+      dev_descriptor : in  unsigned_8);
 
    function is_mounted
-     (id       : in  ewok.tasks_shared.t_task_id;
-      dev_id   : in  ewok.devices_shared.t_device_id)
+     (id             : in  ewok.tasks_shared.t_task_id;
+      dev_descriptor : in  unsigned_8)
       return boolean;
 
    procedure mount_device
-     (id       : in  ewok.tasks_shared.t_task_id;
-      dev_id   : in  ewok.devices_shared.t_device_id;
-      success  : out boolean);
+     (id             : in  ewok.tasks_shared.t_task_id;
+      dev_descriptor : in  unsigned_8;
+      success        : out boolean);
 
    procedure unmount_device
-     (id       : in  ewok.tasks_shared.t_task_id;
-      dev_id   : in  ewok.devices_shared.t_device_id;
-      success  : out boolean);
+     (id             : in  ewok.tasks_shared.t_task_id;
+      dev_descriptor : in  unsigned_8;
+      success        : out boolean);
 
 end ewok.tasks;


### PR DESCRIPTION
- Kernel modules (tasks, sched...) do not need to "understand"
  how the MPU work anymore. The invocated methods are more simple.
- The benefit is that it lead to a better decoupling packages and to an
  increase simplification
- The major drawback is currently a performance penalty (about 3%).
  The explanation is that previous implementation use lot of hardcoded
  value.
