### PR TITLE
[bugfix] deactivate USART RX for kernel console

### DIFF
--- a/src/arch/socs/stm32f439/soc-usart-interfaces.adb
+++ b/src/arch/socs/stm32f439/soc-usart-interfaces.adb
@@ -46,7 +46,9 @@ is
 
       usart.all.CR1.UE     := true; -- USART enable
       usart.all.CR1.TE     := true; -- Transmitter enable
-      usart.all.CR1.RE     := true; -- Receiver enable
+      -- The kernel does not attempt to receive any char from its
+      -- console
+      usart.all.CR1.RE     := false; -- Receiver enable
 
       set_baudrate (usart, baudrate);
 


### PR DESCRIPTION
#### Description:

- Deactivation of the RX support in the USART device configuration

#### Type:

- BUG

#### Rationale:

- The kernel should not be able to receive any char from its serial console. By now, there is no more RX handler in the kernel but the USART was still able to send back received char on interrupt 53, leading to hard fault due to unhandled interrupt.
