### PR TITLE
[enhancement] initial implementation of cross-project PR dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,10 @@ jobs:
               - export PATH=/opt/adacore-arm-eabi/bin:/usr/local/bin:$PATH
               - git config --global color.ui true
               - repo init -u https://github.com/wookey-project/manifest.git -m soft/disco407_nightly.xml && repo sync
+              - export PROJROOT=$PWD;
               - echo 'CROSS_COMPILE=arm-eabi-' > setenv.local.sh
-              - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && git fetch github refs/pull/${TRAVIS_PULL_REQUEST}/head && git checkout FETCH_HEAD; cd ..; fi
+              - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && git fetch github refs/pull/${TRAVIS_PULL_REQUEST}/head && git checkout FETCH_HEAD; cd $PROJROOT; fi
+              - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && for dep in $(git log --oneline refs/pull/${TRAVIS_PULL_REQUEST}/head -n 1 | sed -re 's/.*#depends\((.+)\).*/\1/g'); do cd ${dep%:*}; git fetch github ${dep#*:} && git checkout FETCH_HEAD; cd $OLDPWD; done; cd $PROJROOT; fi
               - source setenv.sh
               - make boards/32f407disco/configs/disco_blinky_ada_defconfig
               - make
@@ -69,6 +71,7 @@ jobs:
               - repo init -u https://github.com/wookey-project/manifest.git -m soft/wookey_nightly.xml && repo sync
               - echo 'CROSS_COMPILE=arm-eabi-' > setenv.local.sh
               - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && git fetch github refs/pull/${TRAVIS_PULL_REQUEST}/head && git checkout FETCH_HEAD; cd ..; fi
+              - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && for dep in $(git log --oneline refs/pull/${TRAVIS_PULL_REQUEST}/head -n 1 | sed -re 's/.*#depends\((.+)\).*/\1/g'); do cd ${dep%:*}; git fetch github ${dep#*:} && git checkout FETCH_HEAD; cd $OLDPWD; done; cd $PROJROOT; fi
               - source setenv.sh
               - make boards/wookey/configs/wookey2_graphic_ada_hs_defconfig
               - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
               - export PATH=/opt/adacore-arm-eabi/bin:/usr/local/bin:$PATH
               - git config --global color.ui true
               - repo init -u https://github.com/wookey-project/manifest.git -m soft/wookey_nightly.xml && repo sync
+              - export PROJROOT=$PWD;
               - echo 'CROSS_COMPILE=arm-eabi-' > setenv.local.sh
               - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && git fetch github refs/pull/${TRAVIS_PULL_REQUEST}/head && git checkout FETCH_HEAD; cd ..; fi
               - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then cd kernel && for dep in $(git log --oneline refs/pull/${TRAVIS_PULL_REQUEST}/head -n 1 | sed -re 's/.*#depends\((.+)\).*/\1/g'); do cd ${dep%:*}; git fetch github ${dep#*:} && git checkout FETCH_HEAD; cd $OLDPWD; done; cd $PROJROOT; fi


### PR DESCRIPTION
#### Description:

- Add support for multi-repositories-based patches, which require to checkout multiple PR in the same time

#### Type:

- WISH 

#### Rationale:

- Some time PR may depends on updates in multiple repositories in the same time (typically EwoK kernel and tataouine). The goal here is to detect this dependencies by adding informational content in the PR title using the following format:

#depends(<relative_to_root_repo>:<ref_path>[ <relalive_to_root_repo>:<ref_path>]*)

