### PR TITLE
Ami/unpriv softirq

### DIFF
--- a/src/ewok-sched.adb
+++ b/src/ewok-sched.adb
@@ -275,13 +275,21 @@ is
       ok       : boolean;
    begin
 
-      -- Kernel tasks are already granted with privileged accesses
+      -- Release previously dynamically allocated regions (used for mapping
+      -- devices and ISR stack)
+      ewok.mpu.unmap_all;
+
+      -- Kernel tasks
       if new_task.ttype = TASK_TYPE_KERNEL then
+         ewok.mpu.update_subregions
+           (region_number  => ewok.mpu.USER_CODE_REGION,
+            subregion_mask => 16#FF#);
+
+         ewok.mpu.update_subregions
+           (region_number  => ewok.mpu.USER_DATA_REGION,
+            subregion_mask => 16#FF#);
          return;
       end if;
-
-      -- Deallocate previously allocated regions and release them
-      ewok.mpu.unmap_all;
 
       --
       -- ISR mode

--- a/src/ewok-softirq.ads
+++ b/src/ewok-softirq.ads
@@ -22,7 +22,6 @@
 
 
 with ewok.tasks_shared; use ewok.tasks_shared;
-with ewok.syscalls;
 with soc.interrupts;
 with rings;
 
@@ -45,12 +44,6 @@ is
       params      : t_isr_parameters;
    end record;
 
-   type t_syscall_request is record
-      caller_id   : ewok.tasks_shared.t_task_id;
-      svc         : ewok.syscalls.t_svc;
-      state       : t_state;
-   end record;
-
    -- softirq input queue depth. Can be configured depending
    -- on the devices behavior (IRQ bursts)
    -- defaulting to 20 (see Kconfig)
@@ -61,22 +54,11 @@ is
 
    isr_queue      : p_isr_requests.ring;
 
-   package p_syscall_requests is new rings (t_syscall_request, MAX_QUEUE_SIZE);
-   use p_syscall_requests;
-
-   syscall_queue  : p_syscall_requests.ring;
-
    procedure init;
 
    procedure push_isr
      (task_id     : in  ewok.tasks_shared.t_task_id;
       params      : in  t_isr_parameters);
-
-   procedure push_syscall
-     (task_id     : in  ewok.tasks_shared.t_task_id;
-      svc         : in  ewok.syscalls.t_svc);
-
-   procedure syscall_handler (req : in  t_syscall_request);
 
    procedure isr_handler (req : in  t_isr_request);
 

--- a/src/ewok-syscalls-handler.adb
+++ b/src/ewok-syscalls-handler.adb
@@ -23,13 +23,13 @@
 with ewok.tasks;        use ewok.tasks;
 with ewok.tasks_shared; use ewok.tasks_shared;
 with ewok.sched;
-with ewok.softirq;
 with ewok.syscalls.cfg.dev;
 with ewok.syscalls.cfg.gpio;
 with ewok.syscalls.gettick;
 with ewok.syscalls.init;
 with ewok.syscalls.ipc;
 with ewok.syscalls.lock;
+with ewok.syscalls.log;
 with ewok.syscalls.reset;
 with ewok.syscalls.rng;
 with ewok.syscalls.sleep;
@@ -143,18 +143,9 @@ is
 
          when SVC_LOG            =>
 
-            -- Svc_log() syscall is postponed (asynchronously executed)
-            if current_a.all.mode = TASK_MODE_MAINTHREAD then
-               ewok.softirq.push_syscall (current_id, svc);
-               ewok.tasks.set_state (current_id, TASK_MODE_MAINTHREAD,
-                  TASK_STATE_SVC_BLOCKED);
-               return ewok.sched.do_schedule (frame_a);
-            else
-               -- Postponed syscalls are forbidden in ISR mode
-               set_return_value
-                 (current_id, TASK_MODE_ISRTHREAD, SYS_E_DENIED);
-               return frame_a;
-            end if;
+            ewok.syscalls.log.svc_log
+              (current_id, svc_params_a.all, current_a.all.mode);
+            return frame_a;
 
          when SVC_REGISTER_DEVICE   =>
             ewok.syscalls.init.svc_register_device


### PR DESCRIPTION
- Hardened the kernel by removing privileges from the SoftIRQ kernel task that can no longer access the whole memory
- Simplified the design by removing syscalls management from SoftIRQ
- Enhanced performance by updating the MPU only when needed
