### PR TITLE
[EXPERIMENTAL][enhancement] add support for rentrancy in EwoK handler mode  #depends(configs/boards/wookey:refs/pull/3/head configs/boards/32f407disco:refs/pull/2/head)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -263,7 +263,16 @@ config KERNEL_EXPERT_MODE
   these options. They may have a great impact on the
   kernel behavior and make the overall system unstable!!!
 
+if KERNEL_EXPERT_MODE
 
+  config KERNEL_EXP_REENTRANCY
+  bool "(Experimental) Enable handler mode reentrancy support"
+  default n
+  ---help---
+  Make kernel interruption handling reentrant to support
+  IRQ preemptions and handling reentrancy based on hardware
+  interrupts priorities
+endif
 
 endmenu
 

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,17 @@ APP_BUILD_DIR = $(BUILD_DIR)/$(DIR_NAME)
 
 BUILD_DIR ?= $(PROJ_FILE)build
 
+AFLAGS += -I$(PROJ_FILES)include/generated
+
 EXTRA_LDFLAGS ?= -Tkernel.ld
 LDFLAGS += $(EXTRA_LDFLAGS) -L$(APP_BUILD_DIR) $(AFLAGS_GCC) -fno-builtin -nostdlib -nostartfiles -Xlinker
 
 LD_LIBS = -lkernel -L$(APP_BUILD_DIR)/Ada/lib
 LD_LIBS += -lgnat -L$(BUILD_DIR)/kernel/libgnat
 
-SOC_ASM := startup.s
+SOC_ASM := startup.S
 SOC_DIR := src/arch/socs/$(SOC)
-SOC_OBJ := $(patsubst %.s,$(APP_BUILD_DIR)/asm/%.o,$(SOC_ASM))
+SOC_OBJ := $(patsubst %.S,$(APP_BUILD_DIR)/asm/%.o,$(SOC_ASM))
 
 # all files in Ada dir will replace C equivalent
 ALIB = $(APP_BUILD_DIR)/Ada/lib/libkernel.a

--- a/src/arch/socs/stm32f407/startup.S
+++ b/src/arch/socs/stm32f407/startup.S
@@ -30,6 +30,8 @@
   ******************************************************************************
   */
 
+#include "autoconf.h"
+
 .syntax unified
 .cpu cortex-m4
 .fpu softvfp
@@ -125,7 +127,9 @@ LoopFillZerobss:
     .weak  Default_Handler
     .type  Default_Handler, %function
 Default_Handler:
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsid   i
+#endif
 
     /*
      * The NVIC has already saved R0-R3, R12, LR, PC and xPSR registers on the
@@ -179,7 +183,9 @@ Default_Handler:
 msp_use:
     /* That branch should never be executed as every task use the PSP */
     msr     msp, r0     /* MSP <- r0 */
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsie   i
+#endif
     bx      lr
 
 psp_use:
@@ -193,14 +199,18 @@ user_mode:
     mov     r0, #3
     msr     control, r0
     isb
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsie   i
+#endif
     bx      lr
 
 kern_mode:
     mov     r0, #2
     msr     control, r0
     isb
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsie   i
+#endif
     bx      lr
 .size Default_Handler, .-Default_Handler
 

--- a/src/arch/socs/stm32f429/startup.S
+++ b/src/arch/socs/stm32f429/startup.S
@@ -30,6 +30,8 @@
   ******************************************************************************
   */
 
+#include "autoconf.h"
+
 .syntax unified
 .cpu cortex-m4
 .fpu softvfp
@@ -125,7 +127,9 @@ LoopFillZerobss:
     .weak  Default_Handler
     .type  Default_Handler, %function
 Default_Handler:
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsid   i
+#endif
 
     /*
      * The NVIC has already saved R0-R3, R12, LR, PC and xPSR registers on the
@@ -179,7 +183,9 @@ Default_Handler:
 msp_use:
     /* That branch should never be executed as every task use the PSP */
     msr     msp, r0     /* MSP <- r0 */
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsie   i
+#endif
     bx      lr
 
 psp_use:
@@ -193,14 +199,18 @@ user_mode:
     mov     r0, #3
     msr     control, r0
     isb
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsie   i
+#endif
     bx      lr
 
 kern_mode:
     mov     r0, #2
     msr     control, r0
     isb
+#ifndef CONFIG_KERNEL_EXP_REENTRANCY
     cpsie   i
+#endif
     bx      lr
 .size Default_Handler, .-Default_Handler
 

--- a/src/arch/socs/stm32f439/startup.S
+++ b/src/arch/socs/stm32f439/startup.S
@@ -1,0 +1,1 @@
+../stm32f407/startup.S

--- a/src/arch/socs/stm32f439/startup.s
+++ b/src/arch/socs/stm32f439/startup.s
@@ -1,1 +1,0 @@
-../stm32f407/startup.s

--- a/src/ewok-isr.adb
+++ b/src/ewok-isr.adb
@@ -68,7 +68,8 @@ is
          end if;
          ewok.dma.clear_dma_interrupts (task_id, intr);
       else
-         -- INFO: this function locks IRQ during its execution
+         -- INFO: this function should be executed as a critical section
+         -- (ToCToU risk)
          ewok.posthook.exec (intr, status, data);
       end if;
 
@@ -81,7 +82,7 @@ is
       isr_params.posthook_status  := status;
       isr_params.posthook_data    := data;
 
-      -- INFO: this function locks IRQ during its execution
+      -- INFO: this function is not reentrant
       ewok.softirq.push_isr (task_id, isr_params);
 
       return;

--- a/src/ewok-isr.adb
+++ b/src/ewok-isr.adb
@@ -68,6 +68,7 @@ is
          end if;
          ewok.dma.clear_dma_interrupts (task_id, intr);
       else
+         -- INFO: this function locks IRQ during its execution
          ewok.posthook.exec (intr, status, data);
       end if;
 
@@ -80,7 +81,9 @@ is
       isr_params.posthook_status  := status;
       isr_params.posthook_data    := data;
 
+      -- INFO: this function locks IRQ during its execution
       ewok.softirq.push_isr (task_id, isr_params);
+
       return;
 
    end postpone_isr;

--- a/src/ewok-posthook.adb
+++ b/src/ewok-posthook.adb
@@ -87,17 +87,21 @@ is
 
       dev_addr := ewok.devices.get_device_addr (dev_id);
 
+#if CONFIG_KERNEL_EXP_REENTRANCY
       -- posthooks are, by now, executed with ISR disabled, to avoid temporal holes
       -- when reading/writing data in device's registers and generating potential
       -- ToCToU
       m4.cpu.disable_irq;
+#end if;
 
       for i in config.all.posthook.action'range loop
          case config.all.posthook.action(i).instr is
 
             when POSTHOOK_NIL    =>
+#if CONFIG_KERNEL_EXP_REENTRANCY
                -- No subsequent action. Returning.
                m4.cpu.enable_irq;
+#end if;
                return;
 
             when POSTHOOK_READ   =>
@@ -218,8 +222,10 @@ is
          end case;
       end loop;
 
-      -- let's enable again IRQs
+#if CONFIG_KERNEL_EXP_REENTRANCY
+      -- Let's enable again IRQs
       m4.cpu.enable_irq;
+#end if;
    end exec;
 
 end ewok.posthook;

--- a/src/ewok-posthook.adb
+++ b/src/ewok-posthook.adb
@@ -87,11 +87,17 @@ is
 
       dev_addr := ewok.devices.get_device_addr (dev_id);
 
+      -- posthooks are, by now, executed with ISR disabled, to avoid temporal holes
+      -- when reading/writing data in device's registers and generating potential
+      -- ToCToU
+      m4.cpu.disable_irq;
+
       for i in config.all.posthook.action'range loop
          case config.all.posthook.action(i).instr is
 
             when POSTHOOK_NIL    =>
                -- No subsequent action. Returning.
+               m4.cpu.enable_irq;
                return;
 
             when POSTHOOK_READ   =>
@@ -212,6 +218,8 @@ is
          end case;
       end loop;
 
+      -- let's enable again IRQs
+      m4.cpu.enable_irq;
    end exec;
 
 end ewok.posthook;

--- a/src/ewok-softirq.adb
+++ b/src/ewok-softirq.adb
@@ -60,14 +60,20 @@ is
       req   : constant t_isr_request := (task_id, WAITING, params);
       ok    : boolean;
    begin
+#if CONFIG_KERNEL_EXP_REENTRANCY
       -- accessing the softirq input queue is not reentrant
       m4.cpu.disable_irq;
+#end if;
       p_isr_requests.write (isr_queue, req, ok);
       if not ok then
+#if CONFIG_KERNEL_EXP_REENTRANCY
          m4.cpu.enable_irq;
+#end if;
          debug.panic ("push_isr() failed.");
       end if;
+#if CONFIG_KERNEL_EXP_REENTRANCY
       m4.cpu.enable_irq;
+#end if;
       ewok.tasks.set_state
         (ID_SOFTIRQ, TASK_MODE_MAINTHREAD, TASK_STATE_RUNNABLE);
    end push_isr;

--- a/src/ewok-softirq.adb
+++ b/src/ewok-softirq.adb
@@ -60,10 +60,14 @@ is
       req   : constant t_isr_request := (task_id, WAITING, params);
       ok    : boolean;
    begin
+      -- accessing the softirq input queue is not reentrant
+      m4.cpu.disable_irq;
       p_isr_requests.write (isr_queue, req, ok);
       if not ok then
+         m4.cpu.enable_irq;
          debug.panic ("push_isr() failed.");
       end if;
+      m4.cpu.enable_irq;
       ewok.tasks.set_state
         (ID_SOFTIRQ, TASK_MODE_MAINTHREAD, TASK_STATE_RUNNABLE);
    end push_isr;


### PR DESCRIPTION
#### Description:

- Add support for reentrancy in handler mode

#### Type:

- IMPROVEMENT,EXPERIMENTAL

#### Rationale:

- Support handler mode (IRQ and exception handling) reentrancy to support multi-priority interrupts handling preemption for better reactivity.
