### PR TITLE
[enhancment] using a generic memory interface for mapping/unmapping

### DIFF
--- a/libkernel.gpr
+++ b/libkernel.gpr
@@ -89,6 +89,7 @@ library project Libkernel is
       "ewok.ipc",
       "ewok.isr",
       "ewok.layout",
+      "ewok.memory",
       "ewok.mpu",
       "ewok.mpu.handler",
       "ewok.perm",

--- a/libkernel.gpr
+++ b/libkernel.gpr
@@ -168,9 +168,11 @@ library project Libkernel is
             for Switches ("soc-dma.adb")                 use perf_switches & debug & verif;
             for Switches ("soc-gpio.adb")                use perf_switches & debug & verif;
             for Switches ("soc-gpio-interfaces.adb")     use perf_switches & debug & verif;
+            for Switches ("ewok-memory.adb")             use perf_switches & debug & verif;
          when "release" =>
             for Default_Switches ("ada") use size_switches & verif;
             for Switches ("ewok-sched.adb")              use perf_switches & verif;
+            for Switches ("ewok-memory.adb")             use perf_switches & verif;
             for Switches ("ewok-tasks.adb")              use perf_switches & verif;
             for Switches ("ewok-interrupts-handler.adb") use perf_switches & verif;
             for Switches ("ewok-syscalls-handler.adb")   use perf_switches & verif;

--- a/src/ewok-devices.adb
+++ b/src/ewok-devices.adb
@@ -28,7 +28,6 @@ with ewok.interrupts;            use ewok.interrupts;
 with ewok.sanitize;
 with ewok.gpio;
 with ewok.exti;
-with ewok.mpu;
 with ewok.debug;
 with ewok.devices.perms;
 with soc.devmap;                 use soc.devmap;
@@ -90,12 +89,12 @@ is
    end get_device_addr;
 
 
-   function is_device_region_ro (dev_id : t_registered_device_id)
+   function is_device_ro (dev_id : t_registered_device_id)
       return boolean
    is
    begin
       return soc.devmap.periphs(registered_device(dev_id).periph_id).ro;
-   end is_device_region_ro;
+   end is_device_ro;
 
 
    function get_device_subregions_mask (dev_id : t_registered_device_id)
@@ -598,41 +597,6 @@ is
 
    end sanitize_user_defined_device;
 
-
-   procedure map_device
-     (dev_id   : in  t_registered_device_id;
-      success  : out boolean)
-   is
-      region_type       : ewok.mpu.t_region_type;
-   begin
-
-      if is_device_region_ro (dev_id) then
-         region_type := ewok.mpu.REGION_TYPE_USER_DEV_RO;
-      else
-         region_type := ewok.mpu.REGION_TYPE_USER_DEV;
-      end if;
-
-      ewok.mpu.map
-        (addr           => get_device_addr (dev_id),
-         size           => get_device_size (dev_id),
-         region_type    => region_type,
-         subregion_mask => get_device_subregions_mask (dev_id),
-         success        => success);
-
-      if not success then
-         pragma DEBUG
-           (debug.log ("mpu_mapping_device(): can not be mapped"));
-      end if;
-
-   end map_device;
-
-
-   procedure unmap_device
-     (dev_id   : in  t_registered_device_id)
-   is
-   begin
-      ewok.mpu.unmap (get_device_addr (dev_id));
-   end unmap_device;
 
 
 end ewok.devices;

--- a/src/ewok-devices.ads
+++ b/src/ewok-devices.ads
@@ -70,7 +70,7 @@ is
    function get_device_addr (dev_id : t_registered_device_id)
       return system_address;
 
-   function is_device_region_ro (dev_id : t_registered_device_id)
+   function is_device_ro (dev_id : t_registered_device_id)
       return boolean;
 
    function get_device_subregions_mask (dev_id : t_registered_device_id)
@@ -99,12 +99,5 @@ is
      (udev     : in  ewok.exported.devices.t_user_device_access;
       task_id  : in  t_task_id)
       return boolean;
-
-   procedure map_device
-     (dev_id   : in  t_registered_device_id;
-      success  : out boolean);
-
-   procedure unmap_device
-     (dev_id   : in  t_registered_device_id);
 
 end ewok.devices;

--- a/src/ewok-memory.adb
+++ b/src/ewok-memory.adb
@@ -1,0 +1,256 @@
+--
+-- Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+--   - Ryad     Benadjila
+--   - Arnauld  Michelizza
+--   - Mathieu  Renard
+--   - Philippe Thierry
+--   - Philippe Trebuchet
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+--     Unless required by applicable law or agreed to in writing, software
+--     distributed under the License is distributed on an "AS IS" BASIS,
+--     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--     See the License for the specific language governing permissions and
+--     limitations under the License.
+--
+--
+
+
+with ada.unchecked_conversion;
+with ewok.mpu;
+with ewok.tasks; use ewok.tasks;
+with ewok.debug;
+with ewok.layout;
+with ewok.devices; use ewok.devices;
+with ewok.devices_shared; use ewok.devices_shared;
+
+package body ewok.memory
+   with spark_mode => off
+is
+
+   -----------------
+   -- Local types --
+   -----------------
+
+   type t_mask is array (unsigned_8 range 1 .. 8) of bit
+      with pack, size => 8;
+
+   -----------------
+   -- Local API   --
+   -----------------
+
+      
+   function to_unsigned_8 is new ada.unchecked_conversion
+      (t_mask, unsigned_8);
+
+
+   procedure map_isr
+      with inline
+   is
+      ok       : boolean;
+   begin
+      ewok.mpu.map
+        (addr           => ewok.layout.STACK_BOTTOM_TASK_ISR,
+         size           => 4096,
+         region_type    => ewok.mpu.REGION_TYPE_ISR_STACK,
+         subregion_mask => 0,
+         success        => ok);
+
+      if not ok then
+         debug.panic ("mpu_switching(): mapping ISR stack failed!");
+      end if;
+   end map_isr;
+
+
+   ------------------------
+   -- Exported Functions --
+   ------------------------
+
+   -- Initialize the memory backend (MPU only by now)
+   procedure init
+     (success : out boolean)
+   is
+   begin
+      ewok.mpu.init(success);
+   end init;
+
+
+   -- Map the given task id
+   procedure map_task(id        : in  t_real_task_id)
+   is
+      new_task : t_task renames ewok.tasks.tasks_list(id);
+      mask     : t_mask := (others => 1);
+   begin
+      for i in 0 .. new_task.num_slots - 1 loop
+         mask(new_task.slot + i) := 0;
+      end loop;
+
+      ewok.mpu.update_subregions
+         (region_number  => ewok.mpu.USER_CODE_REGION,
+         subregion_mask => to_unsigned_8 (mask));
+
+      ewok.mpu.update_subregions
+         (region_number  => ewok.mpu.USER_DATA_REGION,
+         subregion_mask => to_unsigned_8 (mask));
+
+   end map_task;
+
+
+   -- Unmap the currently scheduled task id
+   procedure unmap_task
+   is
+      mask     : constant t_mask := (others => 1);
+   begin
+
+      ewok.mpu.update_subregions
+         (region_number  => ewok.mpu.USER_CODE_REGION,
+         subregion_mask => to_unsigned_8 (mask));
+
+      ewok.mpu.update_subregions
+         (region_number  => ewok.mpu.USER_DATA_REGION,
+         subregion_mask => to_unsigned_8 (mask));
+
+   end unmap_task;
+
+
+   -- Map a given device into the task memory space
+   procedure map_device
+     (dev_id   : in  ewok.devices_shared.t_registered_device_id;
+      success  : out boolean)
+   is
+      region_type       : ewok.mpu.t_region_type;
+   begin
+
+      if is_device_ro (dev_id) then
+         region_type := ewok.mpu.REGION_TYPE_USER_DEV_RO;
+      else
+         region_type := ewok.mpu.REGION_TYPE_USER_DEV;
+      end if;
+
+      ewok.mpu.map
+        (addr           => get_device_addr (dev_id),
+         size           => get_device_size (dev_id),
+         region_type    => region_type,
+         subregion_mask => get_device_subregions_mask (dev_id),
+         success        => success);
+
+      if not success then
+         pragma DEBUG
+           (debug.log ("mpu_mapping_device(): can not be mapped"));
+      end if;
+
+   end map_device;
+
+
+   -- Unmap a given device from the task memory space
+   procedure unmap_device
+     (dev_id   : in  ewok.devices_shared.t_registered_device_id)
+   is
+   begin
+      ewok.mpu.unmap (get_device_addr (dev_id));
+   end unmap_device;
+
+
+   -- Unmap the overall userspace content
+   procedure unmap_userspace
+   is
+   begin
+      ewok.mpu.unmap_userspace;
+   end unmap_userspace;
+
+
+   -- Unmap the dynamic content from the currently scheduled task
+   procedure unmap_dynamics
+   is
+   begin
+      ewok.mpu.unmap_all;
+   end unmap_dynamics;
+
+
+   -- Return true if there is enough space in the memory backend
+   -- to map another element to the currently scheduled task
+   function can_be_mapped return boolean
+   is
+   begin
+      return ewok.mpu.can_be_mapped;
+   end can_be_mapped;
+
+   
+   -- Handle a memory backend switch, from one task to another
+   procedure switch
+     (id : in t_task_id)
+   with spark_mode => off
+   is
+      new_task : t_task renames ewok.tasks.tasks_list(id);
+      dev_id   : t_device_id;
+      ok       : boolean;
+   begin
+
+      -- Release previously dynamically allocated regions (used for mapping
+      -- devices and ISR stack)
+      ewok.memory.unmap_dynamics;
+
+      -- Kernel tasks have no access to user regions
+      if new_task.ttype = TASK_TYPE_KERNEL then
+         unmap_userspace;
+         return;
+      end if;
+
+      --
+      -- ISR mode
+      --
+      if new_task.mode = TASK_MODE_ISRTHREAD then
+
+         -- Mapping the ISR stack
+         map_isr;
+
+         -- Mapping the ISR device
+         dev_id   := new_task.isr_ctx.device_id;
+
+         if dev_id /= ID_DEV_UNUSED then
+            map_device (dev_id, ok);
+
+            if not ok then
+               debug.panic ("mpu_switching(): mapping device failed!");
+            end if;
+         end if;
+
+      --
+      -- Main thread
+      --
+      else
+
+         -- Mapping the user devices
+         --
+         -- Design note:
+         --  - EXTIs are a special case where an interrupt can trigger a
+         --    user ISR without any device_id associated
+         --  - DMAs are not registered in devices
+
+         for i in new_task.devices'range loop
+            if new_task.devices(i).device_id /= ID_DEV_UNUSED and then
+               new_task.devices(i).mounted = true
+            then
+               map_device (new_task.devices(i).device_id, ok);
+               if not ok then
+                  debug.panic ("mpu_switching(): mapping device failed!");
+               end if;
+            end if;
+         end loop;
+
+      end if; -- ISR or MAIN thread
+
+      --------------------------------
+      -- Mapping user code and data --
+      --------------------------------
+      map_task(id);
+
+   end switch;
+
+
+end ewok.memory;

--- a/src/ewok-memory.ads
+++ b/src/ewok-memory.ads
@@ -1,0 +1,117 @@
+--
+-- Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+--   - Ryad     Benadjila
+--   - Arnauld  Michelizza
+--   - Mathieu  Renard
+--   - Philippe Thierry
+--   - Philippe Trebuchet
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+--     Unless required by applicable law or agreed to in writing, software
+--     distributed under the License is distributed on an "AS IS" BASIS,
+--     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--     See the License for the specific language governing permissions and
+--     limitations under the License.
+--
+--
+
+
+with ewok.tasks_shared; use ewok.tasks_shared;
+with ewok.devices_shared;
+with applications; use applications; -- generated
+
+package ewok.memory
+   with spark_mode => off
+is
+
+   ---------------
+   -- Functions --
+   ---------------
+
+   -- Initialize the memory backend (MPU only by now)
+   procedure init
+     (success : out boolean);
+
+
+   -- map the given task id. This function map the data and code sections
+   -- of the given task id, including:
+   --   the task flash content
+   --   the task RAM content (stack, bss, heap...)
+   --
+   -- CAUTION:
+   --    this function does NOT handle specific mapping or unmapping
+   --    (memory devices or ISR map, etc.)
+   --    this function does not handle memory space swith neither
+   --    See belowing API for theses actions.
+   -- 
+   procedure map_task(id        : in  t_real_task_id)
+      with
+         inline;
+
+
+   -- unmap the currently scheduled task id. This is a basic implementation
+   -- no more userspace task is mapped.
+   -- This function unmap the data and code sections of the given task id,
+   -- including:
+   --   the task flash content
+   --   the task RAM content (stack, bss, heap...)
+   --
+   -- CAUTION: this function does NOT handle specific mapping or unmapping
+   -- (memory devices or ISR map, etc.)
+   -- See belowing API for theses actions.
+   procedure unmap_task
+      with
+         inline;
+
+
+   -- Map a given device into the task memory space
+   procedure map_device
+     (dev_id   : in  ewok.devices_shared.t_registered_device_id;
+      success  : out boolean)
+      with
+         inline;
+
+
+   -- Unmap the currently scheduled task id
+   procedure unmap_device
+     (dev_id   : in  ewok.devices_shared.t_registered_device_id)
+     with
+        inline;
+
+
+   -- Unmap the overall userspace content
+   procedure unmap_userspace
+      with inline;
+
+
+   -- Unmap the dynamic content from the currently scheduled task
+   -- This include:
+   --   - IOMapped device(s)
+   --   - ISR stack
+   procedure unmap_dynamics
+      with
+         inline;
+
+
+   -- Return true if there is enough space in the memory backend
+   -- to map another element to the currently scheduled task
+   function can_be_mapped return boolean
+      with inline;
+
+
+   -- Handle a memory backend switch, from one task to another.
+   -- This function handle the following:
+   --   - Unmapping the previously mapped task
+   --   - Map the newly elected task
+   --   - In the case of ISR mode, map the ISR stack and the
+   --     associated device
+   --   - In standard thread mode, map the task's devices
+   procedure switch
+     (id : in t_task_id);
+
+end ewok.memory;

--- a/src/ewok-memory.ads
+++ b/src/ewok-memory.ads
@@ -49,10 +49,8 @@ is
    --    this function does not handle memory space swith neither
    --    See belowing API for theses actions.
    -- 
-   procedure map_task(id        : in  t_real_task_id)
-      with
-         inline;
-
+   procedure map_task(id        : in  t_real_task_id);
+   pragma Inline (map_task);
 
    -- unmap the currently scheduled task id. This is a basic implementation
    -- no more userspace task is mapped.
@@ -64,44 +62,40 @@ is
    -- CAUTION: this function does NOT handle specific mapping or unmapping
    -- (memory devices or ISR map, etc.)
    -- See belowing API for theses actions.
-   procedure unmap_task
-      with
-         inline;
+   procedure unmap_task;
+   pragma Inline (unmap_task);
 
 
    -- Map a given device into the task memory space
    procedure map_device
      (dev_id   : in  ewok.devices_shared.t_registered_device_id;
-      success  : out boolean)
-      with
-         inline;
+      success  : out boolean);
+   pragma Inline (map_device);
 
 
    -- Unmap the currently scheduled task id
    procedure unmap_device
-     (dev_id   : in  ewok.devices_shared.t_registered_device_id)
-     with
-        inline;
+     (dev_id   : in  ewok.devices_shared.t_registered_device_id);
+   pragma Inline (unmap_device);
 
 
    -- Unmap the overall userspace content
-   procedure unmap_userspace
-      with inline;
+   procedure unmap_userspace;
+   pragma Inline (unmap_userspace);
 
 
    -- Unmap the dynamic content from the currently scheduled task
    -- This include:
    --   - IOMapped device(s)
    --   - ISR stack
-   procedure unmap_dynamics
-      with
-         inline;
+   procedure unmap_dynamics;
+   pragma Inline (unmap_dynamics);
 
 
    -- Return true if there is enough space in the memory backend
    -- to map another element to the currently scheduled task
-   function can_be_mapped return boolean
-      with inline;
+   function can_be_mapped return boolean;
+   pragma Inline (can_be_mapped);
 
 
    -- Handle a memory backend switch, from one task to another.
@@ -113,5 +107,6 @@ is
    --   - In standard thread mode, map the task's devices
    procedure switch
      (id : in t_task_id);
+   pragma Inline (switch);
 
 end ewok.memory;

--- a/src/ewok-mpu.adb
+++ b/src/ewok-mpu.adb
@@ -350,6 +350,16 @@ is
       raise program_error;
    end unmap;
 
+   procedure unmap_userspace
+   is
+   begin
+      update_subregions
+         (region_number  => USER_CODE_REGION,
+         subregion_mask  => 16#FF#);
+      update_subregions
+         (region_number  => USER_DATA_REGION,
+         subregion_mask  => 16#FF#);
+   end unmap_userspace;
 
    procedure unmap_all
    is

--- a/src/ewok-mpu.ads
+++ b/src/ewok-mpu.ads
@@ -137,7 +137,14 @@ is
    procedure unmap
      (addr           : in  system_address);
 
-   procedure unmap_all;
+
+   procedure unmap_userspace
+      with
+         inline;
+
+   procedure unmap_all
+      with
+         inline;
 
 
 end ewok.mpu;

--- a/src/ewok-sched.adb
+++ b/src/ewok-sched.adb
@@ -26,12 +26,9 @@ with system.machine_code;
 with ewok.tasks;           use ewok.tasks;
 with ewok.devices_shared;  use ewok.devices_shared;
 with ewok.sleep;
-with ewok.devices;
 with ewok.syscalls.handler;
-with ewok.mpu;
-with ewok.layout;
 with ewok.interrupts;
-with ewok.debug;
+with ewok.memory;
 with soc.interrupts;
 with soc.dwt;
 with m4.scb;
@@ -267,112 +264,6 @@ is
    end task_elect;
 
 
-   procedure mpu_switching
-     (id : in t_task_id)
-   with spark_mode => off
-   is
-      new_task : t_task renames ewok.tasks.tasks_list(id);
-      dev_id   : t_device_id;
-      ok       : boolean;
-   begin
-
-      -- Release previously dynamically allocated regions (used for mapping
-      -- devices and ISR stack)
-      ewok.mpu.unmap_all;
-
-      -- Kernel tasks have no access to user regions
-      if new_task.ttype = TASK_TYPE_KERNEL then
-         ewok.mpu.update_subregions
-           (region_number  => ewok.mpu.USER_CODE_REGION,
-            subregion_mask => 16#FF#);
-         ewok.mpu.update_subregions
-           (region_number  => ewok.mpu.USER_DATA_REGION,
-            subregion_mask => 16#FF#);
-         return;
-      end if;
-
-      --
-      -- ISR mode
-      --
-      if new_task.mode = TASK_MODE_ISRTHREAD then
-
-         -- Mapping the ISR stack
-         ewok.mpu.map
-           (addr           => ewok.layout.STACK_BOTTOM_TASK_ISR,
-            size           => 4096,
-            region_type    => ewok.mpu.REGION_TYPE_ISR_STACK,
-            subregion_mask => 0,
-            success        => ok);
-
-         if not ok then
-            debug.panic ("mpu_switching(): mapping ISR stack failed!");
-         end if;
-
-         -- Mapping the ISR device
-         dev_id   := new_task.isr_ctx.device_id;
-
-         if dev_id /= ID_DEV_UNUSED then
-            ewok.devices.map_device (dev_id, ok);
-
-            if not ok then
-               debug.panic ("mpu_switching(): mapping device failed!");
-            end if;
-         end if;
-
-      --
-      -- Main thread
-      --
-      else
-
-         -- Mapping the user devices
-         --
-         -- Design note:
-         --  - EXTIs are a special case where an interrupt can trigger a
-         --    user ISR without any device_id associated
-         --  - DMAs are not registered in devices
-
-         for i in new_task.devices'range loop
-            if new_task.devices(i).device_id /= ID_DEV_UNUSED and then
-               new_task.devices(i).mounted = true
-            then
-               ewok.devices.map_device (new_task.devices(i).device_id, ok);
-               if not ok then
-                  debug.panic ("mpu_switching(): mapping device failed!");
-               end if;
-            end if;
-         end loop;
-
-      end if; -- ISR or MAIN thread
-
-      --------------------------------
-      -- Mapping user code and data --
-      --------------------------------
-
-      declare
-         type t_mask is array (unsigned_8 range 1 .. 8) of bit
-            with pack, size => 8;
-
-         function to_unsigned_8 is new ada.unchecked_conversion
-           (t_mask, unsigned_8);
-
-         mask : t_mask := (others => 1);
-      begin
-         for i in 0 .. new_task.num_slots - 1 loop
-            mask(new_task.slot + i) := 0;
-         end loop;
-
-         ewok.mpu.update_subregions
-           (region_number  => ewok.mpu.USER_CODE_REGION,
-            subregion_mask => to_unsigned_8 (mask));
-
-         ewok.mpu.update_subregions
-           (region_number  => ewok.mpu.USER_DATA_REGION,
-            subregion_mask => to_unsigned_8 (mask));
-      end;
-
-   end mpu_switching;
-
-
    function pendsv_handler
      (frame_a : ewok.t_stack_frame_access)
       return ewok.t_stack_frame_access
@@ -422,7 +313,7 @@ is
            (current_task_id = old_task_id and
             current_task_mode = old_task_mode)
       then
-         mpu_switching (current_task_id);
+         ewok.memory.switch (current_task_id);
       end if;
 
       -- Return the new context
@@ -503,7 +394,7 @@ is
            (current_task_id = old_task_id and
             current_task_mode = old_task_mode)
       then
-         mpu_switching (current_task_id);
+         ewok.memory.switch (current_task_id);
       end if;
 
       -- Return the new context

--- a/src/ewok-tasks.adb
+++ b/src/ewok-tasks.adb
@@ -28,7 +28,7 @@ with ewok.layout;          use ewok.layout;
 with ewok.ipc;             use ewok.ipc;
 with ewok.rng;
 with ewok.softirq;
-with ewok.devices;
+with ewok.memory;
 with types.c;              use type types.c.t_retval;
 
 with applications; -- Automatically generated
@@ -566,7 +566,7 @@ is
       end if;
 
       -- Mapping the device
-      ewok.devices.map_device
+      ewok.memory.map_device
         (tasks_list(id).devices(dev_descriptor).device_id,
          success);
       if success then
@@ -587,7 +587,7 @@ is
       end if;
 
       -- Unmapping the device
-      ewok.devices.unmap_device
+      ewok.memory.unmap_device
         (tasks_list(id).devices(dev_descriptor).device_id);
       success := true;
    end unmount_device;

--- a/src/main.adb
+++ b/src/main.adb
@@ -34,7 +34,7 @@ with ewok.debug;
 with ewok.dma;
 with ewok.exti;
 with ewok.interrupts;
-with ewok.mpu;
+with ewok.memory;
 with ewok.softirq;
 with ewok.sched;
 with ewok.tasks;
@@ -96,9 +96,9 @@ begin
    -- Initialize the MPU
    -- After this sequence, the kernel is executed with the MPU activated and
    -- can generate memory fault in case of invalid access.
-   ewok.mpu.init (ok);
+   ewok.memory.init (ok);
    if not ok then
-      ewok.debug.panic ("MPU configuration failed!");
+      ewok.debug.panic ("Memory configuration failed!");
    end if;
 
    m4.cpu.instructions.full_memory_barrier;

--- a/src/syscalls/ewok-syscalls-init.adb
+++ b/src/syscalls/ewok-syscalls-init.adb
@@ -27,7 +27,7 @@ with ewok.exported.devices;   use ewok.exported.devices;
 with ewok.devices;
 with ewok.sanitize;
 with ewok.dma;
-with ewok.mpu;
+with ewok.memory;
 with ewok.perm;
 with ewok.sched;
 with ewok.debug;
@@ -114,7 +114,7 @@ is
 
       if (udev.map_mode = DEV_MAP_AUTO  and  -- Device should be automatically mapped...
           udev.size > 0)
-         and then not ewok.mpu.can_be_mapped -- ...but no sufficient resources
+         and then not ewok.memory.can_be_mapped -- ...but no sufficient resources
       then
          pragma DEBUG (debug.log (debug.ERROR,
             "svc_register_device(): no free region left to map the device"));

--- a/src/syscalls/ewok-syscalls-ipc.adb
+++ b/src/syscalls/ewok-syscalls-ipc.adb
@@ -30,7 +30,7 @@ with ewok.sanitize;
 with ewok.perm;
 with ewok.sleep;
 with ewok.debug;
-with ewok.mpu;
+with ewok.memory;
 with types.c;           use types.c;
 
 
@@ -303,9 +303,9 @@ is
             -- data region in memory can not be accessed (even by the kernel).
             -- The following temporary open the access to every task's data
             -- region, perform the writing, and then restore the MPU.
-            ewok.mpu.enable_unrestricted_kernel_access;
+            ewok.memory.map_task(id_sender);
             set_return_value (id_sender, TASK_MODE_MAINTHREAD, SYS_E_DONE);
-            ewok.mpu.disable_unrestricted_kernel_access;
+            ewok.memory.map_task(caller_id);
 
             TSK.set_state
               (id_sender, TASK_MODE_MAINTHREAD, TASK_STATE_RUNNABLE);
@@ -564,10 +564,10 @@ is
 
          -- Unrestrict kernel access to memory to change a value located
          -- in the receiver's stack frame
-         ewok.mpu.enable_unrestricted_kernel_access;
+         ewok.memory.map_task(id_receiver);
          receiver_a.all.ctx.frame_a.all.PC :=
             receiver_a.all.ctx.frame_a.all.PC - 2;
-         ewok.mpu.disable_unrestricted_kernel_access;
+         ewok.memory.map_task(caller_id);
       end if;
 
       if blocking then


### PR DESCRIPTION
## Description:

- Add support for abtracted memory backend management for portability between various MPU subsystems and potential future MMU-based systems

#### Type:

- IMPROVEMENT

#### Rationale:

- Allows a simplification of the memory backend access through higher level API
- Permits to support a unified model of memory abstraction
