### PR TITLE
[bugfix] add missing unmap flag set. typo for harden (not freezing) mode

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -65,6 +65,13 @@ endif
 choice
   prompt "Kernel Panic behavior"
   default KERNEL_PANIC_FREEZE
+    config KERNEL_PANIC_FAULT
+    bool "Set the task as fault"
+    ---help---
+       When a panic() happen due to a userspace fault, lock the
+       responsible task, making it unschedulable. Other task can
+       still be schedule. This imply a new scheduling event.
+       INFO: This is not a safe behavior on embedded systems!
     config KERNEL_PANIC_FREEZE
     bool "Freeze on panic"
     ---help---

--- a/src/ewok-mpu-handler.adb
+++ b/src/ewok-mpu-handler.adb
@@ -27,7 +27,6 @@ with ewok.tasks.debug;
 with ewok.tasks_shared;    use ewok.tasks_shared;
 with ewok.devices_shared;  use ewok.devices_shared;
 with ewok.sched;
-with ewok.debug;
 with soc.interrupts;
 
 package body ewok.mpu.handler
@@ -39,7 +38,7 @@ is
       return t_stack_frame_access
    is
 #if not CONFIG_KERNEL_PANIC_FREEZE
-      new_frame_a : t_stack_frame_access
+      new_frame_a : t_stack_frame_access;
 #end if;
    begin
       pragma DEBUG (ewok.tasks.debug.crashdump (frame_a));

--- a/src/ewok-tasks.adb
+++ b/src/ewok-tasks.adb
@@ -589,6 +589,7 @@ is
       -- Unmapping the device
       ewok.memory.unmap_device
         (tasks_list(id).devices(dev_descriptor).device_id);
+      tasks_list(id).devices(dev_descriptor).mounted := false;
       success := true;
    end unmount_device;
 


### PR DESCRIPTION
#### Description:

- When unmapping a device, the kernel doesn't set the device map flag to false
- Typo in hardened mode (when using other modes that FREEZE_ON_PANIC)

#### Type:

- BUG 

