### PR TITLE
[WIP][bugfix] corrected carriage return bug for specific sys_log() call

### DIFF
--- a/src/ewok-debug.adb
+++ b/src/ewok-debug.adb
@@ -174,6 +174,11 @@ is
    is
    begin
       for i in s'range loop
+         -- we need carriage return on serial interface, in addition to POSIX standard
+         -- newline character
+         if s(i) = ASCII.LF then
+            putc (ASCII.CR);
+         end if;
          putc (s(i));
       end loop;
       if nl then

--- a/src/syscalls/ewok-syscalls-log.adb
+++ b/src/syscalls/ewok-syscalls-log.adb
@@ -54,8 +54,14 @@ is
          goto ret_inval;
       end if;
 
+      -- here, we print the userspace message with a prefix named after the
+      -- calling task name. The newline char is under the responsability of
+      -- the calling task (standard printf() behavior), meaning that no newline
+      -- char means that no line return is created.
+      -- In case of multiple newline chars in msg, the debug.log handles the
+      -- carriage return for each of them
       pragma DEBUG (debug.log
-        (ewok.tasks.tasks_list(caller_id).name & " " & msg & ASCII.CR,
+        (ewok.tasks.tasks_list(caller_id).name & " " & msg,
          false));
 
       set_return_value (caller_id, mode, SYS_E_DONE);


### PR DESCRIPTION
#### Description:

- invalid carriage return handling when no newline is used at end of userspace buffer

#### Type:

- BUG 

#### Rationale:

Ideally, the kernel should not patch the message string itself. The userspace message string is prefixed with the task name in order to increase the readability of the overall log interface, but the message string may include 0, 1, or multiple newlines. Each of them should be handled properly (meaning adding the carriage return char, as the output is a serial console). No other modification should be done (adding carriage if there is no newline for e.g.)
