### PR TITLE
[bugfix] stm32f429 missing content and CAN support

### DIFF
--- a/src/arch/socs/stm32f407/soc-rcc.adb
+++ b/src/arch/socs/stm32f407/soc-rcc.adb
@@ -134,6 +134,8 @@ is
          when SPI1      => soc.rcc.RCC.APB2ENR.SPI1EN    := true;
          when SPI2      => soc.rcc.RCC.APB1ENR.SPI2EN    := true;
          when SPI3      => soc.rcc.RCC.APB1ENR.SPI3EN    := true;
+         when CAN1      => soc.rcc.RCC.APB1ENR.CAN1EN    := true;
+         when CAN2      => soc.rcc.RCC.APB1ENR.CAN2EN    := true;
          when USART1    => soc.rcc.RCC.APB2ENR.USART1EN  := true;
          when USART6    => soc.rcc.RCC.APB2ENR.USART6EN  := true;
          when USART2    => soc.rcc.RCC.APB1ENR.USART2EN  := true;

--- a/src/arch/socs/stm32f429/soc-layout.ads
+++ b/src/arch/socs/stm32f429/soc-layout.ads
@@ -16,6 +16,13 @@ is
    RAM_BASE          : constant system_address := 16#2000_0000#; -- SRAM
    RAM_SIZE          : constant := 128 * KBYTE;
 
+   USER_RAM_BASE     : constant system_address := 16#2000_0000#; -- SRAM
+   USER_RAM_SIZE     : constant := 128 * KBYTE;
+
+   KERNEL_RAM_BASE   : constant system_address := 16#1000_0000#;
+   KERNEL_RAM_SIZE   : constant := 64 * KBYTE;
+
+
    PERIPH_BASE       : constant system_address := 16#4000_0000#;
    MEMORY_BANK1_BASE : constant system_address := 16#6000_0000#;
    MEMORY_BANK2_BASE : constant system_address := MEMORY_BANK1_BASE;

--- a/src/arch/socs/stm32f429/soc-pwr.ads
+++ b/src/arch/socs/stm32f429/soc-pwr.ads
@@ -1,1 +1,1 @@
-../stm32f439/soc-pwr.ads
+../stm32f407/soc-pwr.ads

--- a/src/arch/socs/stm32f429/soc-rcc.adb
+++ b/src/arch/socs/stm32f429/soc-rcc.adb
@@ -1,1 +1,1 @@
-../stm32f439/soc-rcc.adb
+../stm32f407/soc-rcc.adb


### PR DESCRIPTION
#### Description:

- Update support for CANx and patch compilation failure on STM32F429 boards

#### Type:

- BUG 

#### Rationale:

- bugfix
- Add CANx as CAN devices are accessible on Disco 429
